### PR TITLE
install es6-shim typings for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 npm-debug.log
 node_modules
+typings
 example/node_modules
 example/app/**/**.js
 .idea

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.56",
   "description": "An easy to use notification library for angular 2",
   "scripts": {
-    "build": "tsc"
+    "build": "typings install && tsc"
   },
   "repository": {
     "type": "git",
@@ -27,16 +27,16 @@
     "@angular/core": "^2.0.0-rc.1",
     "rxjs": "5.0.0-beta.6"
   },
-  "main": "./components.js",
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "typescript": "^1.8.10",
-    "typings": "^0.7.12",
     "@angular/core": "^2.0.0-rc.1",
     "es6-shim": "^0.35.0",
+    "gulp": "^3.9.1",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.6",
+    "typescript": "^1.8.10",
+    "typings": "^0.7.12",
     "zone.js": "~0.6.12"
   },
+  "main": "./components.js",
   "typings": "./components.d.ts"
 }

--- a/src/pushNotifications.service.ts
+++ b/src/pushNotifications.service.ts
@@ -8,7 +8,7 @@ export class PushNotificationsService {
     private notificationBuffer: PushNotification;
 
     create(data: PushNotification): any {
-        
+
         if (!this.canCreate) {
             this.notificationBuffer = data;
             this.getPermission();
@@ -49,7 +49,7 @@ export class PushNotificationsService {
     }
 }
 
-interface PushNotification {
+export interface PushNotification {
     title: string
     body: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "declaration": true
   },
   "files": [
+    "typings/browser.d.ts",
+    "components.d.ts",
     "src/icons.ts",
     "src/max.pipe.ts",
     "src/notification.component.ts",

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,5 @@
+{
+  "ambientDependencies": {
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504"
+  }
+}


### PR DESCRIPTION
This should fix #31. Since angular went to RC, they have removed the es6-shim typings from the core. So you need to install it manually in order to have the ts compiler understand the interfaces of items like Promise, ...

_Note : I have not tested these changes in a real world example. But the build works and all files seem to be correctly generated in the lib folder_