### PR TITLE
fix: Update svg width for IE toast

### DIFF
--- a/src/notification.component.ts
+++ b/src/notification.component.ts
@@ -137,7 +137,7 @@ import {Icons} from "./icons"
             box-sizing: border-box;
             top: 0;
             right: 0;
-            width: auto;
+            width: 70px;
             height: 70px;
             padding: 10px;
             fill: #fff;


### PR DESCRIPTION
The div containing the SVG item displays improperly in IE because width: auto does not compute to 70px in the same manner as other browsers.