### PR TITLE
refactoring to remove implicit any type in simple-notification.compon…

### DIFF
--- a/example/app/app.ts
+++ b/example/app/app.ts
@@ -1,6 +1,7 @@
-import "rxjs/Rx";
-import {Component} from "@angular/core";
-import {NotificationsService, SimpleNotificationsComponent} from "angular2-notifications"
+import 'rxjs/Rx';
+import {Component, OnInit} from '@angular/core';
+import {NotificationsService, SimpleNotificationsComponent} from 'angular2-notifications';
+import {Options} from '../../src/options.type';
 
 @Component({
     selector: "app",
@@ -43,7 +44,7 @@ import {NotificationsService, SimpleNotificationsComponent} from "angular2-notif
     `
 })
 
-export class AppComponent {
+export class AppComponent implements OnInit{
     constructor(
         private _service: NotificationsService
     ) {}
@@ -56,26 +57,18 @@ export class AppComponent {
 
     public temp: boolean[] = [true, false];
 
-    public options = {
-        timeOut: 5000,
-        lastOnBottom: true,
-        clickToClose: true,
-        maxLength: 0,
-        maxStack: 7,
-        showProgressBar: true,
-        pauseOnHover: true,
-        preventDuplicates: false,
-        preventLastDuplicates: "visible",
-        rtl: false,
-        animate: "scale",
-        position: ["right", "bottom"]
-    };
+    public options: Options;
 
     private html = `<p>Test</p><p>A nother test</p>`;
 
     // createPush() {
     //     this._push.create({title: "test", body: "bla"})
     // }
+
+    ngOnInit(): void {
+        this.options = new Options();
+        this.options.animate = 'scale'
+    }
 
     create() {
         switch (this.type) {

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -5,7 +5,7 @@ export interface Icons {
   success: string;
 }
 
-export let defaultIcons = {
+export let defaultIcons: Icons = {
   alert: `
         <svg class="simple-notification-svg" xmlns="http://www.w3.org/2000/svg" fill="#000000" height="24" viewBox="0 0 24 24" width="24">
             <path d="M0 0h24v24H0z" fill="none"/>

--- a/src/notification-type.ts
+++ b/src/notification-type.ts
@@ -1,4 +1,0 @@
-export interface NotificationType {
-  name: string;
-  color: string;
-}

--- a/src/notification.component.ts
+++ b/src/notification.component.ts
@@ -2,18 +2,17 @@ import {
   Component,
   OnInit,
   OnDestroy,
-  ViewEncapsulation,
   trigger,
   state,
   style,
   transition,
   animate,
-  Input
+  Input,
+  ViewEncapsulation
 } from '@angular/core';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {Notification} from './notification.type';
 import {NotificationsService} from './notifications.service';
-import {Icons} from './icons';
 
 @Component({
   selector: 'simple-notification',
@@ -182,16 +181,19 @@ import {Icons} from './icons';
 export class NotificationComponent implements OnInit, OnDestroy {
 
   @Input()
-  public icons: Icons;
-
-  @Input()
-  public item: Notification;
-
-  @Input()
-  public maxLength: number;
+  public timeOut: number;
 
   @Input()
   public showProgressBar: boolean;
+
+  @Input()
+  public pauseOnHover: boolean;
+
+  @Input()
+  public clickToClose: boolean;
+
+  @Input()
+  public maxLength: number;
 
   @Input()
   public theClass: string;
@@ -203,18 +205,10 @@ export class NotificationComponent implements OnInit, OnDestroy {
   public animate: string;
 
   @Input()
-  public timeOut: number;
-
-  @Input()
   public position: number;
 
   @Input()
-  public clickToClose: boolean;
-
-  @Input()
-  public pauseOnHover: boolean;
-
-  public overrides: any;
+  public item: Notification;
 
 
   // Progress bar variables
@@ -237,14 +231,15 @@ export class NotificationComponent implements OnInit, OnDestroy {
     if (this.animate) {
       this.item.state = this.animate;
     }
-    if (this.item.override) {
-      this.attachOverrides();
-    }
+    // Is it need? The variable of Notification class is not the same of the nofitication.component
+    // if (this.item.override) {
+    //   this.attachOverrides();
+    // }
     if (this.timeOut !== 0) {
       this.startTimeOut();
     }
 
-    this.safeSvg = this.domSanitizer.bypassSecurityTrustHtml(this.icons[this.item.type]);
+    this.safeSvg = this.domSanitizer.bypassSecurityTrustHtml(this.item.icon);
   }
 
   startTimeOut(): void {
@@ -278,9 +273,13 @@ export class NotificationComponent implements OnInit, OnDestroy {
   }
 
   // Attach all the overrides
-  attachOverrides(): void {
-    Object.keys(this.item.override).forEach(a => this[a] = this.item.override[a]);
-  }
+  // attachOverrides(): void {
+  //   Object.keys(this.item.override).forEach(a => {
+  //     if (this.hasOwnProperty(a)) {
+  //       this[a] = this.item.override[a];
+  //     }
+  //   });
+  // }
 
   ngOnDestroy(): void {
     clearTimeout(this.timer);

--- a/src/notification.type.ts
+++ b/src/notification.type.ts
@@ -1,6 +1,7 @@
 export interface Notification {
   id?: string;
   type: string;
+  icon: string;
   title?: string;
   content?: string;
   override?: any;

--- a/src/notifications.service.ts
+++ b/src/notifications.service.ts
@@ -2,17 +2,18 @@ import {Injectable} from '@angular/core';
 import {Subject} from 'rxjs/Rx';
 import {NotificationEvent} from './notification-event';
 import {Notification} from './notification.type';
+import {Icons, defaultIcons} from './icons';
 
 @Injectable()
 export class NotificationsService {
 
   private emitter: Subject<NotificationEvent> = new Subject<NotificationEvent>();
+  private icons: Icons = defaultIcons;
 
   set(notification: Notification, to: boolean) {
     notification.id = notification.override && notification.override.id ? notification.override.id : Math.random().toString(36).substring(3);
     this.emitter.next({command: 'set', notification: notification, add: to});
     return notification;
-
   };
 
   getChangeEmitter() {
@@ -21,33 +22,39 @@ export class NotificationsService {
 
   //// Access methods
   success(title: string, content: string, override?: any) {
-    return this.set({title: title, content: content, type: 'success', override: override}, true);
+    return this.set({
+      title: title,
+      content: content,
+      type: 'success',
+      icon: this.icons.success,
+      override: override
+    }, true);
   }
 
   error(title: string, content: string, override?: any) {
-    return this.set({title: title, content: content, type: 'error', override: override}, true);
+    return this.set({title: title, content: content, type: 'error', icon: this.icons.error, override: override}, true);
   }
 
   alert(title: string, content: string, override?: any) {
-    return this.set({title: title, content: content, type: 'alert', override: override}, true);
+    return this.set({title: title, content: content, type: 'alert', icon: this.icons.alert, override: override}, true);
   }
 
   info(title: string, content: string, override?: any) {
-    return this.set({title: title, content: content, type: 'info', override: override}, true);
+    return this.set({title: title, content: content, type: 'info', icon: this.icons.info, override: override}, true);
   }
 
   bare(title: string, content: string, override?: any) {
-    return this.set({title: title, content: content, type: 'bare', override: override}, true);
+    return this.set({title: title, content: content, type: 'bare', icon: 'bare', override: override}, true);
   }
 
   // With type method
   create(title: string, content: string, type: string, override?: any) {
-    return this.set({title: title, content: content, type: type, override: override}, true);
+    return this.set({title: title, content: content, type: type, icon: 'bare', override: override}, true);
   }
 
   // HTML Notification method
   html(html: any, type: string, override?: any) {
-    return this.set({html: html, type: type, override: override, title: null, content: null}, true);
+    return this.set({html: html, type: type, icon: 'bare', override: override, title: null, content: null}, true);
   }
 
   // Remove all notifications method

--- a/src/options.type.ts
+++ b/src/options.type.ts
@@ -1,18 +1,15 @@
-import {Icons} from './icons';
-
-export interface Options {
-  timeOut?: number;
-  showProgressBar?: boolean;
-  pauseOnHover?: boolean;
-  lastOnBottom?: boolean;
-  clickToClose?: boolean;
-  maxLength?: number;
-  maxStacks?: number;
-  preventDuplicates?: number;
-  preventLastDuplicates?: boolean | string;
+export class Options {
+  timeOut?: number = 6000;                         // default 0
+  showProgressBar?: boolean = true;                // default true
+  pauseOnHover?: boolean = true;                   // default true
+  lastOnBottom?: boolean = true; //default true
+  clickToClose?: boolean = true; //true
+  maxLength?: number = 0; //0
+  maxStacks?: number = 7;
+  preventDuplicates?: boolean = false;
+  preventLastDuplicates?: boolean | string = false;
   theClass?: string;
-  rtl?: boolean;
-  animate?: 'fromRight' | 'fromLeft' | 'rotate' | 'scale';
-  icons?: Icons;
-  position?: ['top' | 'bottom', 'right' | 'left'];
+  rtl?: boolean = false;
+  animate?: 'fromRight' | 'fromLeft' | 'rotate' | 'scale' = 'fromRight';  // default 'fromRight';
+  position?: ['top' | 'bottom', 'right' | 'left'] = ['bottom', 'right'];
 }


### PR DESCRIPTION
*** Need update aplication example, version and node repository :D

Refactorins in simple-notification.component

Remove unused variable expand from simple-notification.component
Refactoring simple-notification.component to use Options class
Remove attachChanges method
Add type Subscription to listener variable in simple-notification.component
Remove _ into internal/private variable, this is not necessari in TypeScript
indexOfDelete maybe not initialized
Change Options to contain default values, now is a class not interface
declar variable to use default value
optionsToNotification: Options = new Options();

modify default value in ngOnInit()
  ngOnInit(): void {
    this.optionsToNotification = new Options();
    this.optionsToNotification.timeOut = 5000;
  }

refactoring above need to remove implicit any type on attachChanges method

Rename variable a in ngFor to notification, and in cleanSingle method

I beleve that attachOverride in notification.component is not need, be cause, the variable of Notification class is not the same of the nofitication.component


Refactorins Below  need to remove implicit type from ngOnInit (this.safeSvg = this.domSanitizer.bypassSecurityTrustHtml(this.icons[this.item.type]);)
  Move Icons (Default) to notificationService
  Remove icon to simple-notification
  Remove icon from notification.component
  Remove incons from Options class
  Set icon into access methods (success, error, alert, info)
  Need icon to bare?
  type is not icon, need two variable to represent both 
  add type in return of buildEmit method


Remove notification-type.ts (no use)


need automated testes :D