### PR TITLE
fix: add padding to title to fix css overlap with icon #83

### DIFF
--- a/src/notification.component.ts
+++ b/src/notification.component.ts
@@ -116,7 +116,7 @@ import {NotificationsService} from './notifications.service';
 
         .simple-notification .sn-title {
             margin: 0;
-            padding: 0;
+            padding: 0 50px 0 0;
             line-height: 30px;
             font-size: 20px;
         }


### PR DESCRIPTION
<img width="323" alt="screen shot 2016-10-08 at 9 51 41 pm" src="https://cloud.githubusercontent.com/assets/2547722/19217888/155ec844-8da5-11e6-8ea1-d740f5ef6e02.png">
