### PR TITLE
export Notification from notification.type

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -2,6 +2,7 @@ export { SimpleNotificationsModule } from './src/simple-notifications.module';
 export { SimpleNotificationsComponent } from './src/simple-notifications.component';
 export { NotificationComponent } from './src/notification.component';
 export { NotificationsService } from './src/notifications.service';
+export { Notification} from './src/notification.type';
 export { MaxPipe } from './src/max.pipe';
 export { PushNotificationsModule } from './src/push-notifications.module';
 export { PushNotificationsService } from './src/push-notifications.service';


### PR DESCRIPTION
Export Notification from notification.type which is useful in typeScript return type for example:

 ``` TypeScript
method1(param1: string, param2: string): void | Notification {
    if(condition)
      return this.notificationService.error('ERROR', 'Summary');
    }
  }
```