### PR TITLE
Usage in multiple shared modules

### DIFF
--- a/src/simple-notifications.module.ts
+++ b/src/simple-notifications.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NotificationsService} from './notifications.service';
 import {SimpleNotificationsComponent} from './simple-notifications.component';

--- a/src/simple-notifications.module.ts
+++ b/src/simple-notifications.module.ts
@@ -8,8 +8,16 @@ import {MaxPipe} from './max.pipe';
 @NgModule({
   imports: [CommonModule],
   declarations: [SimpleNotificationsComponent, NotificationComponent, MaxPipe],
-  providers: [NotificationsService],
+  providers: [],
   exports: [SimpleNotificationsComponent]
 })
 export class SimpleNotificationsModule {
+  public static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: SimpleNotificationsModule,
+      providers: [
+        NotificationsService
+      ]
+    };
+  }
 }


### PR DESCRIPTION
Update in order to use the same instance of the notifications service in different shared modules.

forRoot() is called in the main app module only.