### PR TITLE
Need to call .forRoot() in toast docs when importing from AppModule #146

### DIFF
--- a/docs/toastNotifications.md
+++ b/docs/toastNotifications.md
@@ -3,10 +3,10 @@ Toast notifications are regular on-page notifications.
 
 ## Setup
 
-Import the `SimpleNotificationsModule` in to your `AppModule`
+Import the `SimpleNotificationsModule` in to your root `AppModule`
 ```ts
 @NgModule({
-    imports: [BrowserModule, SimpleNotificationsModule],
+    imports: [BrowserModule, SimpleNotificationsModule.forRoot()],
     declarations: [AppComponent],
     bootstrap: [AppComponent]
 })


### PR DESCRIPTION
After 313ca4def29bdc178c0ef03a26456df349862a56, in the root AppModule, this results in an `No provider for NotificationsService!` error:

```ts
    imports: [BrowserModule, SimpleNotificationsModule]
```

Changing to this works:
```ts
    imports: [BrowserModule, SimpleNotificationsModule.forRoot()]
```

Just updating the usage docs. #146 