### PR TITLE
Adds missing line of code

### DIFF
--- a/docs/toastNotifications.md
+++ b/docs/toastNotifications.md
@@ -5,6 +5,8 @@ Toast notifications are regular on-page notifications.
 
 Import the `SimpleNotificationsModule` in to your root `AppModule`
 ```ts
+import { SimpleNotificationsModule } from 'angular2-notifications';
+
 @NgModule({
     imports: [BrowserModule, SimpleNotificationsModule.forRoot()],
     declarations: [AppComponent],


### PR DESCRIPTION
Since it's not clear that the module is not named the same as the node-module folder that gets created by npm. Since angular-next is going to be  version 4 I suggest changing the library name (ie. don't call it angular2 anymore)