### PR TITLE
fix maxStack propertyName; root export some Interfaces

### DIFF
--- a/components.ts
+++ b/components.ts
@@ -6,5 +6,5 @@ export { MaxPipe } from './src/max.pipe';
 
 export { PushNotificationsModule } from './src/push-notifications.module';
 export { PushNotificationsService } from './src/push-notifications.service';
-export { Icons, DefaultIcons } from './src/icons';
+export { Icons, defaultIcons } from './src/icons';
 export { Options } from './src/options.type';

--- a/components.ts
+++ b/components.ts
@@ -6,3 +6,5 @@ export { MaxPipe } from './src/max.pipe';
 
 export { PushNotificationsModule } from './src/push-notifications.module';
 export { PushNotificationsService } from './src/push-notifications.service';
+export { Icons, DefaultIcons } from './src/icons';
+export { Options } from './src/options.type';

--- a/src/options.type.ts
+++ b/src/options.type.ts
@@ -7,7 +7,7 @@ export interface Options {
   lastOnBottom?: boolean;
   clickToClose?: boolean;
   maxLength?: number;
-  maxStacks?: number;
+  maxStack?: number;
   preventDuplicates?: number;
   preventLastDuplicates?: boolean | string;
   theClass?: string;


### PR DESCRIPTION
Hello. I've found you using `maxStack` definition in Docs and in code, but in `Options` there is `maxStacks` now.
Also it's better to export `Options` interface so that one could use it without importing from deeper folder