### PR TITLE
Fix icon showing bare for create/html

### DIFF
--- a/src/notification.component.ts
+++ b/src/notification.component.ts
@@ -79,7 +79,7 @@ import {NotificationsService} from './notifications.service';
                 <div class="sn-title">{{item.title}}</div>
                 <div class="sn-content">{{item.content | max:maxLength}}</div>
 
-                <div class="icon" *ngIf="item.type !== 'bare'" [innerHTML]="safeSvg"></div>
+                <div class="icon" *ngIf="item.icon !== 'bare'" [innerHTML]="safeSvg"></div>
             </div>
             <div *ngIf="item.html" [innerHTML]="item.html"></div>
 


### PR DESCRIPTION
The call to `NotificationsService.create` will create a notification with icon as `bare` and type as something which can be different than `bare`. The test in the template only test for the type and not the icon, so if the icon is `bare` and the type is not, there is a `bare` text in the notification box.