### PR TITLE
Rollback targetting to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "module": "commonjs",
-    "target": "ES6",
+    "target": "es6",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowUnusedLabels": false,


### PR DESCRIPTION
The change to ES6 targetting leads to some side effect on both prod build and on some testing runners (PhantomJS for example).

It should work in a better proper way under angular-cli `ng test` command when using some ES5 only runners (which fails due to angular2-notification, even if `tsconfig.spec.json` at tested project level targets es5 and polyfills are set).

Should fix: #186 and #183 

Is the es6 targetting necessary for something special on angular2-notifications ?