### PR TITLE
chore(tsconfig): change targetting from es6 to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowUnusedLabels": false,


### PR DESCRIPTION
Fix an error in my previous PR as targetting version was unchanged.
Instead ES6 was simply transformed to es6. But it doesn't fix PhantomJS problem.

Bump down targetting to es5 as a more proper fix.

To be review and approved by @flauc 