### PR TITLE
fixed codelyzer path

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": [
-    "node_modules/codelyzer"
+    "../codelyzer"
   ],
   "rules": {
     "class-name": true,


### PR DESCRIPTION
Seeing as codelyzer and angular2-notifications are in the same dir, this should do the trick.