### PR TITLE
Use icons from override-object if set

### DIFF
--- a/src/simple-notifications/components/simple-notifications.component.ts
+++ b/src/simple-notifications/components/simple-notifications.component.ts
@@ -120,6 +120,11 @@ export class SimpleNotificationsComponent implements OnInit, OnDestroy {
 
         // Save this as the last created notification
         this.lastNotificationCreated = item;
+        
+        // Override icon if set
+        if (item.override && item.override.icons && item.override.icons[item.type]) {
+            item.icon = item.override.icons[item.type];
+        }
 
         if (!toBlock) {
             // Check if the notification should be added at the start or the end of the array


### PR DESCRIPTION
Depending on #165 - This fixes the issue for overriding the icon for a single notification