### PR TITLE
Override icons in general

### DIFF
--- a/src/simple-notifications/components/simple-notifications.component.ts
+++ b/src/simple-notifications/components/simple-notifications.component.ts
@@ -182,6 +182,8 @@ export class SimpleNotificationsComponent implements OnInit, OnDestroy {
         Object.keys(options).forEach(a => {
             if (this.hasOwnProperty(a)) {
                 (<any>this)[a] = options[a];
+            } else if (a === 'icons') {
+                this._service.icons = options[a];
             }
         });
     }

--- a/src/simple-notifications/services/notifications.service.ts
+++ b/src/simple-notifications/services/notifications.service.ts
@@ -8,7 +8,7 @@ import {Icons, defaultIcons} from '../interfaces/icons';
 export class NotificationsService {
 
   private emitter: Subject<NotificationEvent> = new Subject<NotificationEvent>();
-  private icons: Icons = defaultIcons;
+  public icons: Icons = defaultIcons;
 
   set(notification: Notification, to: boolean) {
     notification.id = notification.override && notification.override.id ? notification.override.id : Math.random().toString(36).substring(3);


### PR DESCRIPTION
Also depending on #165 - this allows us to override the default icons by setting them inside of the service, or adding them to the [options]-object.