### PR TITLE
Fix clickIconToClose

### DIFF
--- a/src/components/notification/notification.component.css
+++ b/src/components/notification/notification.component.css
@@ -13,16 +13,20 @@
 
 .simple-notification .sn-title {
     margin: 0;
-    padding: 0 50px 0 0;
     line-height: 30px;
     font-size: 20px;
 }
 
+
 .simple-notification .sn-content {
     margin: 0;
     font-size: 16px;
-    padding: 0 50px 0 0;
     line-height: 20px;
+}
+
+.simple-notification.has-icon .sn-title,
+.simple-notification.has-icon .sn-content {
+    padding: 0 50px 0 0;
 }
 
 .simple-notification .icon {
@@ -49,12 +53,13 @@
     fill: #fff;
 }
 
-.simple-notification.rtl-mode {
-    direction: rtl;
+.simple-notification.rtl-mode.has-icon .sn-title,
+.simple-notification.rtl-mode.has-icon .sn-content {
+    padding: 0 0 0 50px;
 }
 
-.simple-notification.rtl-mode .sn-content {
-    padding: 0 0 0 50px;
+.simple-notification.rtl-mode {
+    direction: rtl;
 }
 
 .simple-notification.rtl-mode svg {

--- a/src/components/notification/notification.component.html
+++ b/src/components/notification/notification.component.html
@@ -9,7 +9,8 @@
             'success': item.type === 'success',
             'info': item.type === 'info',
             'bare': item.type === 'bare',
-            'rtl-mode': rtl
+            'rtl-mode': rtl,
+            'has-icon': item.icon || (item.icon && item.icon !== 'bare')
         }"
      (mouseenter)="onEnter()"
      (mouseleave)="onLeave()">

--- a/src/components/notification/notification.component.html
+++ b/src/components/notification/notification.component.html
@@ -32,7 +32,7 @@
             <div class="sn-content" [innerHTML]="content"></div>
         </ng-template>
 
-        <div class="icon" *ngIf="item.icon !== 'bare'" [innerHTML]="safeSvg"></div>
+        <div class="icon" [class.icon-hover]="clickIconToClose" *ngIf="item.icon !== 'bare'" [innerHTML]="safeSvg" (click)="onClickIcon($event)"></div>
     </div>
     <div *ngIf="item.html">
         <div class="sn-content" [innerHTML]="item.html"></div>

--- a/src/components/notification/notification.component.ts
+++ b/src/components/notification/notification.component.ts
@@ -153,6 +153,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    console.log('wesh');
     if (this.item.override) {
       this.attachOverrides();
     }
@@ -194,7 +195,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
   onClick($e: MouseEvent): void {
     this.item.click!.emit($e);
 
-    if (this.clickToClose) {
+    if (this.clickToClose && !this.clickIconToClose) {
       this.remove();
     }
   }

--- a/src/components/notification/notification.component.ts
+++ b/src/components/notification/notification.component.ts
@@ -153,7 +153,6 @@ export class NotificationComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    console.log('wesh');
     if (this.item.override) {
       this.attachOverrides();
     }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -13,6 +13,7 @@ export class NotificationsService {
     set(notification: Notification, to: boolean): Notification {
         notification.id = notification.override && notification.override.id ? notification.override.id : Math.random().toString(36).substring(3);
         notification.click = new EventEmitter<{}>();
+        notification.clickIcon = new EventEmitter<{}>();
 
         this.emitter.next({command: 'set', notification: notification, add: to});
         return notification;


### PR DESCRIPTION
This pull request add the missing EventEmitter `clickIcon` & make works `clickIconToClose`for all notification type (not only "html")
In the same time I added a class `.has-icon` to add paddind to `.sn-title` & `.sn-content` only if the notification has an icon