### PR TITLE
Added mising typings to package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular2-notifications",
+  "typings": "./dist/index.d.ts",
   "version": "1.0.1",
   "scripts": {
     "build": "gulp build",


### PR DESCRIPTION
This addition solves a problem produced by
angular-cli by not detecting some files at
Typescript's AOT compilation (ng build --prod
and ng serve --aot).