### PR TITLE
converts Position to support typescript 2.7

### DIFF
--- a/src/interfaces/options.type.ts
+++ b/src/interfaces/options.type.ts
@@ -1,6 +1,11 @@
 import {Icons} from './icons';
 
-export type Position = ['top' | 'bottom' | 'middle', 'right' | 'left' | 'center'];
+export type VerticalPosition = 'top' | 'bottom' | 'middle';
+export type HorizontalPosition = 'right' | 'left' | 'center';
+export interface Position extends Array<VerticalPosition | HorizontalPosition> {
+    0: VerticalPosition;
+    1: HorizontalPosition;
+}
 export type Animate = 'fade' | 'fromTop' | 'fromRight' | 'fromBottom' | 'fromLeft' | 'rotate' | 'scale';
 
 export interface Options {


### PR DESCRIPTION
Instead of a rather sloppy approach to create a tuple with 3 by 3 choices, the prefered interface structure of typescript 2.7 is used (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#fixed-length-tuples).