### PR TITLE
Detach notifications view from the change-detection tree on ngOnDestroy

### DIFF
--- a/src/components/notification/notification.component.ts
+++ b/src/components/notification/notification.component.ts
@@ -176,6 +176,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     clearTimeout(this.timer);
+    this.cdr.detach();
   }
 
   startTimeOut(): void {
@@ -236,7 +237,11 @@ export class NotificationComponent implements OnInit, OnDestroy {
 
       this.timer = setTimeout(this.instance, this.sleepTime);
     }
-    this.zone.run(() => this.cdr.detectChanges());
+    this.zone.run(() => {
+      if (!this.cdr['destroyed']) {
+        this.cdr.detectChanges();
+      }
+    });
   }
 
   private remove() {

--- a/src/components/simple-notifications/simple-notifications.component.ts
+++ b/src/components/simple-notifications/simple-notifications.component.ts
@@ -88,8 +88,9 @@ export class SimpleNotificationsComponent implements OnInit, OnDestroy {
             this.defaultBehavior(item);
             break;
         }
-
-        this.cdr.detectChanges();
+        if (!this.cdr['destroyed']) {
+          this.cdr.detectChanges();
+        }
       });
   }
 
@@ -97,6 +98,7 @@ export class SimpleNotificationsComponent implements OnInit, OnDestroy {
     if (this.listener) {
       this.listener.unsubscribe();
     }
+    this.cdr.detach();
   }
 
   // Default behavior on event


### PR DESCRIPTION
My previous commit was not a full fix for https://github.com/flauc/angular2-notifications/issues/296. This one should completely solve the problem.