### PR TITLE
Set TemplateRef data by context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.0
+
+### Notes
+
+* Added template context management
+
 # 0.9.5
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -110,35 +110,37 @@ This are the currently available access methods:
 
 | Method | Description
 ---| ---
-`success(title: any, content?: any, override?: any)` | Creates a success notification with the provided title and content.
-`error(title: any, content?: any, override?: any)`  | Creates an error notification with the provided title and content.
-`alert(title: any, content?: any, override?: any)` | Creates an alert notification with the provided title and content.
-`warn(title: any, content?: any, override?: any)` | Creates a warn notification with the provided title and content.
-`info(title: any, content?: any, override?: any)` | Creates an info notification with the provided title and content.
-`bare(title: any, content?: any, override?: any)` | Creates a bare notification with the provided title and content. This notification type is best used when adding custom html.
-`create(title: any, content: any = '', type: string = 'success', override?: any)` | Use this method to create any notification type ['success', 'error', 'alert', 'info', 'bare'].
-`html(html: any, type: string = 'success', override?: any, icon: string = 'bare')` | Use this method to create a notification with custom html. By specifying an icon (success, error, alert, info or warn) you can use the default icons in addition to your custom html. If you do not explicitly pass an icon param no icon will be shown by default.
+`success(title: any, content?: any, override?: any, context?: any)` | Creates a success notification with the provided title and content.
+`error(title: any, content?: any, override?: any, context?: any)`  | Creates an error notification with the provided title and content.
+`alert(title: any, content?: any, override?: any, context?: any)` | Creates an alert notification with the provided title and content.
+`warn(title: any, content?: any, override?: any, context?: any)` | Creates a warn notification with the provided title and content.
+`info(title: any, content?: any, override?: any, context?: any)` | Creates an info notification with the provided title and content.
+`bare(title: any, content?: any, override?: any, context?: any)` | Creates a bare notification with the provided title and content. This notification type is best used when adding custom html.
+`create(title: any, content: any = '', type: string = 'success', override?: any, context?: any)` | Use this method to create any notification type ['success', 'error', 'alert', 'info', 'bare'].
+`html(html: any, type: string = 'success', override?: any, icon: string = 'bare', context?: any)` | Use this method to create a notification with custom html. By specifying an icon (success, error, alert, info or warn) you can use the default icons in addition to your custom html. If you do not explicitly pass an icon param no icon will be shown by default.
 `remove(id?: string)` | Removes the notification that has the provided id or removes all currently open notifications if no id was provided.
 
-The `title` and `content` arguments can be a string, html string or `TemplateRef`.
+The `title`, `content` and `html` arguments can be a string, html string or `TemplateRef`. Now it's also possible to pass the datas (context) to the `TemplateRef` by using the optional `context` argument.
 
 ### Example using `TemplateRef`
 
 To use a `TemplateRef` in the title or content you need to create it in a component template: 
 
 ```html
-<ng-template #example>
-    <p>Simple example</p>
+<ng-template #example let-title="title">
+    <p>{{title}}</p>
 </ng-template>
 ```
 
 Then you need to somehow get it to the component: 
 
-```ts 
+```ts
+  title: string = 'Winter is coming';
   @ViewChild('example') example: TemplateRef<any>;
 
   open() {
-    this._service.success(this.example);
+    let context: any = {title: this.title};
+    this._service.html(this.example, null, null, null, context);
   }
 ```
 
@@ -146,7 +148,7 @@ You could also pass the template through the `open()` method:
 
 ```ts
     open(temp: TemplateRef<any>) {
-        this._service.success(temp);
+        this._service.html(temp, null, null, null, context);
     }
 ```
 

--- a/src/components/notification/notification.component.html
+++ b/src/components/notification/notification.component.html
@@ -18,7 +18,7 @@
     <div *ngIf="!item.html">
 
         <div class="sn-title" *ngIf="titleIsTemplate; else regularTitle">
-            <ng-container *ngTemplateOutlet="title"></ng-container>
+            <ng-container *ngTemplateOutlet="title; context: item.context"></ng-container>
         </div>
 
         <ng-template #regularTitle>
@@ -26,7 +26,7 @@
         </ng-template>
 
         <div class="sn-content" *ngIf="contentIsTemplate else regularContent">
-            <ng-container *ngTemplateOutlet="content"></ng-container>
+            <ng-container *ngTemplateOutlet="content; context: item.context"></ng-container>
         </div>
 
         <ng-template #regularContent>
@@ -37,7 +37,7 @@
     </div>
     <div *ngIf="item.html">
         <div class="sn-html" *ngIf="htmlIsTemplate; else regularHtml">
-            <ng-container *ngTemplateOutlet="item.html"></ng-container>
+            <ng-container *ngTemplateOutlet="item.html; context: item.context"></ng-container>
         </div>
 
         <ng-template #regularHtml>

--- a/src/interfaces/notification.type.ts
+++ b/src/interfaces/notification.type.ts
@@ -23,4 +23,5 @@ export interface Notification {
   click?: EventEmitter<{}>;
   clickIcon?: EventEmitter<{}>;
   timeoutEnd?: EventEmitter<{}>;
+  context?: any;
 }

--- a/src/services/notifications.service.ts
+++ b/src/services/notifications.service.ts
@@ -25,38 +25,38 @@ export class NotificationsService {
     return notification;
   };
 
-  success(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Success, icon: this.icons.success, override: override}, true);
+  success(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Success, icon: this.icons.success, override: override, context: context}, true);
   }
 
-  error(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Error, icon: this.icons.error, override: override}, true);
+  error(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Error, icon: this.icons.error, override: override, context: context}, true);
   }
 
-  alert(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Alert, icon: this.icons.alert, override: override}, true);
+  alert(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Alert, icon: this.icons.alert, override: override, context: context}, true);
   }
 
-  info(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Info, icon: this.icons.info, override: override}, true);
+  info(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Info, icon: this.icons.info, override: override, context: context}, true);
   }
 
-  warn(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Warn, icon: this.icons.warn, override: override}, true);
+  warn(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Warn, icon: this.icons.warn, override: override, context: context}, true);
   }
 
-  bare(title: any = '', content: any = '', override?: any): Notification {
-    return this.set({title: title, content: content || '', type: NotificationType.Bare, icon: 'bare', override: override}, true);
+  bare(title: any = '', content: any = '', override?: any, context?: any): Notification {
+    return this.set({title: title, content: content || '', type: NotificationType.Bare, icon: 'bare', override: override, context: context}, true);
   }
 
   // With type method
-  create(title: any = '', content: any = '', type = NotificationType.Success, override?: any): Notification {
-    return this.set({title: title, content: content, type: type, icon: (<any>this.icons)[type], override: override}, true);
+  create(title: any = '', content: any = '', type = NotificationType.Success, override?: any, context?: any): Notification {
+    return this.set({title: title, content: content, type: type, icon: (<any>this.icons)[type], override: override, context: context}, true);
   }
 
   // HTML Notification method
-  html(html: any, type = NotificationType.Success, override?: any, icon = 'bare'): Notification {
-    return this.set({html: html, type: type, icon: (<any>this.icons)[icon], override: override}, true);
+  html(html: any, type = NotificationType.Success, override?: any, icon = 'bare', context?: any): Notification {
+    return this.set({html: html, type: type, icon: (<any>this.icons)[icon], override: override, context: context}, true);
   }
 
   // Remove all notifications method


### PR DESCRIPTION
Hi, I would like to merge my fork that simply gives a way to set the data for the TemplateRef by using a new optional parameter. 

Each method now have the optional parameter called 'context' that allows to set our custom and dynamic content.

Obviously the notifications are dynamic so it's strictly necessary a way to pass data in the TemplateRef case.