### PR TITLE
Same class of HTML wrapper element

### DIFF
--- a/src/lib/components/notification/notification.component.html
+++ b/src/lib/components/notification/notification.component.html
@@ -41,7 +41,7 @@
         </div>
 
         <ng-template #regularHtml>
-            <div class="sn-content" [innerHTML]="safeInputHtml"></div>
+            <div class="sn-html" [innerHTML]="safeInputHtml"></div>
         </ng-template>
 
         <div class="icon" [class.icon-hover]="clickIconToClose" *ngIf="item.icon" [innerHTML]="safeSvg" (click)="onClickIcon($event)"></div>


### PR DESCRIPTION
When creating a custom Notification with the `NotificationService.html()` method, the `sn-content` class was added around the entire HTML code one passed to the method. This should have been the `sn-html` class, in my opinion.

When creating the notification from an Angular template, the class `sn-html` is added, which looks correct to me. I changed the code so that the `sn-html` class is assigned in both cases.