### PR TITLE
fix: don't import BrowserAnimationsModule in a library

### DIFF
--- a/src/lib/simple-notifications.module.ts
+++ b/src/lib/simple-notifications.module.ts
@@ -5,7 +5,6 @@ import { SimpleNotificationsComponent } from './components/simple-notifications/
 import { DEFAULT_OPTIONS } from './consts/default-options.const';
 import { Options } from './interfaces/options.type';
 import { NotificationsService } from './services/notifications.service';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 export const OPTIONS = new InjectionToken<Options>('options');
 export function optionsFactory(options) {
@@ -18,7 +17,6 @@ export function optionsFactory(options) {
 @NgModule({
   imports: [
     CommonModule,
-    BrowserAnimationsModule,
   ],
   declarations: [
     SimpleNotificationsComponent,


### PR DESCRIPTION
Leave importing BrowserAnimationsModule to the application or else lazy loaded routes will error that BrowserModule has already been loaded.

fixes #392 